### PR TITLE
Add contributors guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thanks for your interest in contributing to OpenChart. This guide aims to outlin
 In order to keep everything consistent and readable, we ask that any code you write adheres to the the [C# Coding Conventions](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/inside-a-program/coding-conventions). 
 
 ### Documentation
-We require that any public classes, methods or properties include [XMLdocs](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/xmldoc/). Please include a description of what the method/class/property is for, as well as any method arguments. You can usually generate these automatically by typing three forward slashes (`///`) - in Visual Studio Code, [there is an extension to facilitate this](https://marketplace.visualstudio.com/items?itemName=k--kato.docomment).
+We require that any public classes, methods or properties include [XMLdocs](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/xmldoc/). Please include a description of what the method/class/property is for, as well as any method arguments. You can usually generate these automatically by typing three forward slashes (`///`) - in Visual Studio Code, [there is an extension to enable this](https://marketplace.visualstudio.com/items?itemName=k--kato.docomment).
 
 ### Formatting
 To keep the formatting consistent, it might be helpful for you to use the automatic formatting tools built into your IDE or text editor of choice.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing to OpenChart
+
+Thanks for your interest in contributing to OpenChart. This guide aims to outline some of the standards we've set for contributions to the project.
+
+## Coding standards
+In order to keep the standards of our codebase high, we ask that any code you write adheres to the the [C# Coding Conventions](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/inside-a-program/coding-conventions). This helps to keep everything consistent and readable. 
+
+Also, in the interest of maintaining proper documentation, we require that any public classes, methods or properties include [XMLdocs](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/xmldoc/). Please include a description of what the method/class/property is for, as well as any method arguments. You can usually generate these automatically by typing three forward slashes (`///`) - in Visual Studio Code, [there is an extension to facilitate this](https://marketplace.visualstudio.com/items?itemName=k--kato.docomment).
+
+To keep the formatting consistent, it might be helpful for you to use the automatic formatting tools built into your IDE or text editor of choice.
+
+In addition, we ask that where possible, any code you write is covered with clear, concise unit tests. This really helps us to ensure that any regressions are caught in the future, and gives us a fighting chance at not releasing buggy code.
+
+## Pull requests and issues
+When raising pull requests and issues, please provide a brief description of the proposed changes and why you think they are justified. Moreover, when reporting bugs as issues, please provide any steps you take to reproduce the bug, as well as any other information you think might be useful (system specs, operating system, etc.). 
+
+This comes in extremely useful when project maintainers come to review any proposed changes or bugfixes, and helps us push things through without having to ask too many questions.
+
+Please base any pull requests on the `develop` branch.
+
+## Any questions?
+
+We're here to help you make a success out of any contributions to OpenChart. If you need help or have any questions, [please join our Discord server](https://discord.gg/Eyn479Q).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,13 +3,16 @@
 Thanks for your interest in contributing to OpenChart. This guide aims to outline some of the standards we've set for contributions to the project.
 
 ## Coding standards
-In order to keep the standards of our codebase high, we ask that any code you write adheres to the the [C# Coding Conventions](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/inside-a-program/coding-conventions). This helps to keep everything consistent and readable. 
+In order to keep everything consistent and readable, we ask that any code you write adheres to the the [C# Coding Conventions](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/inside-a-program/coding-conventions). 
 
-Also, in the interest of maintaining proper documentation, we require that any public classes, methods or properties include [XMLdocs](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/xmldoc/). Please include a description of what the method/class/property is for, as well as any method arguments. You can usually generate these automatically by typing three forward slashes (`///`) - in Visual Studio Code, [there is an extension to facilitate this](https://marketplace.visualstudio.com/items?itemName=k--kato.docomment).
+### Documentation
+We require that any public classes, methods or properties include [XMLdocs](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/xmldoc/). Please include a description of what the method/class/property is for, as well as any method arguments. You can usually generate these automatically by typing three forward slashes (`///`) - in Visual Studio Code, [there is an extension to facilitate this](https://marketplace.visualstudio.com/items?itemName=k--kato.docomment).
 
+### Formatting
 To keep the formatting consistent, it might be helpful for you to use the automatic formatting tools built into your IDE or text editor of choice.
 
-In addition, we ask that where possible, any code you write is covered with clear, concise unit tests. This really helps us to ensure that any regressions are caught in the future, and gives us a fighting chance at not releasing buggy code.
+### Unit testing
+We ask that where possible, any code you write is covered with clear, concise unit tests. This really helps us to ensure that any regressions are caught in the future, and gives us a fighting chance at not releasing buggy code.
 
 ## Pull requests and issues
 When raising pull requests and issues, please provide a brief description of the proposed changes and why you think they are justified. Moreover, when reporting bugs as issues, please provide any steps you take to reproduce the bug, as well as any other information you think might be useful (system specs, operating system, etc.). 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,4 +20,4 @@ Please base any pull requests on the `develop` branch.
 
 ## Any questions?
 
-We're here to help you make a success out of any contributions to OpenChart. If you need help or have any questions, [please join our Discord server](https://discord.gg/Eyn479Q).
+We're here to help you make a success out of any contributions to OpenChart. If you need help or have any questions, [please join our Discord server](https://discord.gg/wSGmN52).


### PR DESCRIPTION
This PR adds a contributors guide to help new contributors to look at the standards we have in place for contributions to the project.