### PR TITLE
Setup publish config and GitHub action

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,13 +4,16 @@ on: ["push", "pull_request"]
 jobs:
   build:
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v2
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 3.1.101
+
       - name: Build
         run: make build
+
       - name: Test
         run: make test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,20 +1,16 @@
 name: Build and test
-on:
-  push:
-  pull_request:
+on: ["push", "pull_request"]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 3.1.101
-    - name: Build
-      run: make build
-    - name: Test
-      run: make test
+      - uses: actions/checkout@v2
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.101
+      - name: Build
+        run: make build
+      - name: Test
+        run: make test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v2
       - name: Setup .NET Core
@@ -22,10 +23,12 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: build
-          path: /
+          path: .
 
   publish-linux:
     runs-on: ubuntu-latest
+    needs: build
+
     steps:
       - uses: actions/checkout@v2
       - name: Setup .NET Core
@@ -49,6 +52,8 @@ jobs:
 
   publish-osx:
     runs-on: macos-latest
+    needs: build
+
     steps:
       - uses: actions/checkout@v2
       - name: Setup .NET Core
@@ -72,6 +77,8 @@ jobs:
 
   publish-win:
     runs-on: windows-latest
+    needs: build
+
     steps:
       - uses: actions/checkout@v2
       - name: Setup .NET Core

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,7 @@
 name: Publish apps
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+  release:
 
 jobs:
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,43 @@
+name: Publish apps
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.101
+
+    - name: Build
+      run: make build
+
+    - name: Publish
+      run: make publish
+
+    # Upload linux artifacts
+    - uses: actions/upload-artifact@v1
+      with:
+        name: linux-x64
+        path: dist/linux-x64
+
+    # Upload macOS artifacts
+    - uses: actions/upload-artifact@v1
+      with:
+        name: osx-x64
+        path: dist/osx-x64
+
+    # Upload windows artifacts
+    - uses: actions/upload-artifact@v1
+      with:
+        name: win-x64
+        path: dist/win-x64

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,5 @@
 name: Publish apps
 on:
-  release:
   push:
     branches:
       - master

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,4 @@
 name: Publish apps
-
 on:
   release:
   push:
@@ -8,9 +7,7 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
       - name: Setup .NET Core
@@ -29,7 +26,6 @@ jobs:
 
   publish-linux:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
       - name: Setup .NET Core
@@ -53,7 +49,6 @@ jobs:
 
   publish-osx:
     runs-on: macos-latest
-
     steps:
       - uses: actions/checkout@v2
       - name: Setup .NET Core
@@ -77,7 +72,6 @@ jobs:
 
   publish-win:
     runs-on: windows-latest
-
     steps:
       - uses: actions/checkout@v2
       - name: Setup .NET Core

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,9 @@ name: Publish apps
 
 on:
   release:
+  push:
+    branches:
+      - master
 
 jobs:
   build:
@@ -9,32 +12,89 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 3.1.101
+      - uses: actions/checkout@v2
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.101
 
-    - name: Build
-      run: make build
+      - name: Build
+        run: make build
 
-    - name: Publish
-      run: make publish
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: build
+          path: /
 
-    # Upload linux artifacts
-    - uses: actions/upload-artifact@v1
-      with:
-        name: linux-x64
-        path: dist/linux-x64
+  publish-linux:
+    runs-on: ubuntu-latest
 
-    # Upload macOS artifacts
-    - uses: actions/upload-artifact@v1
-      with:
-        name: osx-x64
-        path: dist/osx-x64
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.101
 
-    # Upload windows artifacts
-    - uses: actions/upload-artifact@v1
-      with:
-        name: win-x64
-        path: dist/win-x64
+      - name: Download build
+        uses: actions/download-artifact@v1
+        with:
+          name: build
+
+      - name: Publish
+        run: make publish-linux
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: linux-x64
+          path: dist/linux-x64
+
+  publish-osx:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.101
+
+      - name: Download build
+        uses: actions/download-artifact@v1
+        with:
+          name: build
+
+      - name: Publish
+        run: make publish-osx
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: osx-x64
+          path: dist/osx-x64
+
+  publish-win:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.101
+
+      - name: Download build
+        uses: actions/download-artifact@v1
+        with:
+          name: build
+
+      - name: Publish
+        run: make publish-win
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: win-x64
+          path: dist/win-x64

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin/
+dist/
 obj/

--- a/Makefile
+++ b/Makefile
@@ -33,17 +33,18 @@ cleanall: clean
 publish: publish-linux publish-osx publish-win
 
 publish-linux:
-	rm -rf $(publish_dir)/linux_x64
+	rm -rf $(publish_dir)/linux-x64
 	dotnet publish -o $(publish_dir)/linux-x64 -r linux-x64 -c Release OpenChart
 	cp -r $(lib_dir)/x64/*.so $(assets_dir)/* $(publish_dir)/linux-x64
 
 publish-osx:
-	rm -rf $(publish_dir)/osx
+	rm -rf $(publish_dir)/osx-x64
 	dotnet publish -o $(publish_dir)/osx-x64 -r osx-x64 -c Release OpenChart
+	chmod +x $(publish_dir)/osx-x64/OpenChart
 	cp -r $(lib_dir)/osx/* $(assets_dir)/* $(publish_dir)/osx-x64
 
 publish-win:
-	rm -rf $(publish_dir)/win
+	rm -rf $(publish_dir)/win-x64
 	dotnet publish -o $(publish_dir)/win-x64 -r win-x64 -c Release OpenChart
 	cp -r $(lib_dir)/x64/*.dll $(assets_dir)/* $(publish_dir)/win-x64
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL := /bin/bash
 assets_dir := OpenChart/assets
 lib_dir := OpenChart/lib
 output_dir := bin
-project_file := OpenChart/OpenChart.csproj
+publish_dir := dist
 
 # OS detection. Do not assume the existence of uname on Windows.
 ifeq ($(OS), Windows_NT)
@@ -12,10 +12,10 @@ else
 endif
 
 all: build run
-.PHONY: all build clean cleanall run test
+.PHONY: all build clean cleanall publish publish-linux publish-osx publish-win run test
 
 build:
-	dotnet build -o $(output_dir) $(project_file)
+	dotnet build -o $(output_dir) OpenChart/OpenChart.csproj
 
 	@# Copy dependencies and runtime assets
 	@if [[ "$(detected_os)" == "Darwin" ]]; then \
@@ -25,10 +25,27 @@ build:
 	fi
 
 clean:
-	rm -rf $(output_dir) OpenChart/bin/ OpenChart.Tests/bin/
+	rm -rf $(output_dir) $(publish_dir) OpenChart/bin/ OpenChart.Tests/bin/
 
 cleanall: clean
 	rm -rf OpenChart/obj/ OpenChart.Tests/obj/
+
+publish: publish-linux publish-osx publish-win
+
+publish-linux:
+	rm -rf $(publish_dir)/linux_x64
+	dotnet publish -o $(publish_dir)/linux-x64 -r linux-x64 -c Release OpenChart
+	cp -r $(lib_dir)/x64/*.so $(assets_dir)/* $(publish_dir)/linux-x64
+
+publish-osx:
+	rm -rf $(publish_dir)/osx
+	dotnet publish -o $(publish_dir)/osx-x64 -r osx-x64 -c Release OpenChart
+	cp -r $(lib_dir)/osx/* $(assets_dir)/* $(publish_dir)/osx-x64
+
+publish-win:
+	rm -rf $(publish_dir)/win
+	dotnet publish -o $(publish_dir)/win-x64 -r win-x64 -c Release OpenChart
+	cp -r $(lib_dir)/x64/*.dll $(assets_dir)/* $(publish_dir)/win-x64
 
 run:
 	@echo

--- a/OpenChart/OpenChart.csproj
+++ b/OpenChart/OpenChart.csproj
@@ -3,12 +3,21 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
+
+  <!-- Publish configuration -->
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DebugType>None</DebugType>
+    <PublishSingleFile>false</PublishSingleFile>
+    <PublishTrimmed>true</PublishTrimmed>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Remove="**\*.glade" />
     <EmbeddedResource Include="**\*.glade">
       <LogicalName>%(Filename)%(Extension)</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="GtkSharp" Version="3.22.25.*" />
     <PackageReference Include="ManagedBass" Version="2.0.4" />

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ pacman -S mingw-w64-x86_64-gtk3
 - `make test`: runs the test suite.
 - `make clean`: cleans `bin/` folders.
 - `make cleanall`: cleans both `bin/` and `obj/` folders. Run `dotnet restore` to redownload dependencies.
+- `make publish`: publishes the project for Linux, macOS, and Windows into `dist/`.
+- `make publish-linux`: publishes the project for Linux x64 into `dist/`.
+- `make publish-osx`: publishes the project for macOS x64 into `dist/`.
+- `make publish-win`: publishes the project for Windows x64 into `dist/`.
 
 ## Visual Studio Code
 


### PR DESCRIPTION
Publishing compiles a standalone version of the app for each OS (linux, macOS, windows). The apps are bundled with all dependencies (including .NET).

Also added a GitHub action to build the publish artifacts when a new release is created. Ideally we should be able to just grab those and attach them to the release.